### PR TITLE
log level for env_logger now configurable config file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,12 @@ port = 12201
 level = "INFO"
 ```
 
+# Optional logging config, to log to stderr
+[logging.console]
+## Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
+level = "INFO"
+```
+
 #### Metrics
 
 Throttle supports Prometheus metrics, via the `/metrics` endpoint. Depending on your configuration and state they may e.g. look like this:

--- a/Readme.md
+++ b/Readme.md
@@ -86,7 +86,7 @@ level = "INFO"
 
 
 # Optional logging config, to log to stderr
-[logging.console]
+[logging.stderr]
 # Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
 level = "INFO"
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -81,13 +81,13 @@ A = 42
 name = "MyThrottleServer"
 host = "my_graylog_instance.cloud"
 port = 12201
-## Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
+# Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
 level = "INFO"
-```
+
 
 # Optional logging config, to log to stderr
 [logging.console]
-## Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
+# Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
 level = "INFO"
 ```
 

--- a/src/application_cfg.rs
+++ b/src/application_cfg.rs
@@ -111,4 +111,13 @@ mod tests {
         let actual: ApplicationCfg = toml::from_str(cfg).unwrap();
         assert!(actual.logging.gelf.is_some());
     }
+
+    #[test]
+    fn parse_console_logging_config() {
+        let cfg = "[logging.console]\n\
+                    level = \"DEBUG\"\n\
+                ";
+        let actual: ApplicationCfg = toml::from_str(cfg).unwrap();
+        assert!(actual.logging.console.is_some());
+    }
 }

--- a/src/application_cfg.rs
+++ b/src/application_cfg.rs
@@ -114,10 +114,10 @@ mod tests {
 
     #[test]
     fn parse_console_logging_config() {
-        let cfg = "[logging.console]\n\
+        let cfg = "[logging.stderr]\n\
                     level = \"DEBUG\"\n\
                 ";
         let actual: ApplicationCfg = toml::from_str(cfg).unwrap();
-        assert!(actual.logging.console.is_some());
+        assert!(actual.logging.stderr.is_some());
     }
 }

--- a/src/application_cfg.rs
+++ b/src/application_cfg.rs
@@ -118,6 +118,6 @@ mod tests {
                     level = \"DEBUG\"\n\
                 ";
         let actual: ApplicationCfg = toml::from_str(cfg).unwrap();
-        assert!(actual.logging.stderr.is_some());
+        assert_eq!(actual.logging.stderr.level, "DEBUG");
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 pub struct LoggingConfig {
     /// Configures a Gelf Logger
     pub gelf: Option<GelfConfig>,
+    pub console: Option<ConsoleConfig>
 }
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
@@ -21,6 +22,12 @@ pub struct GelfConfig {
     level: log::LevelFilter,
     /// E.g. "12201"
     port: u16,
+}
+
+#[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
+pub struct ConsoleConfig {
+    /// E.g. "INFO" or "DEBUG"
+    level: String
 }
 
 /// Initialize GELF logger if `logging_config.json` is found in the working directory.
@@ -38,7 +45,11 @@ pub fn init(config: &LoggingConfig) -> Result<(), Error> {
         eprintln!(
             "Gelf logger config not found => Using environment logger writing to stderr instead."
         );
-        env_logger::from_env("THROTTLE_LOG").init();
+        if let Some(ref config) = config.console {
+            env_logger::from_env(env_logger::Env::default().filter_or("THROTTLE_LOG", config.level.as_str())).init();
+        } else {
+            env_logger::from_env("THROTTLE_LOG").init();
+        }
     }
     Ok(())
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 pub struct LoggingConfig {
     /// Configures a Gelf Logger
     pub gelf: Option<GelfConfig>,
-    pub console: Option<ConsoleConfig>
+    pub stderr: Option<StdErrConfig>
 }
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
@@ -25,7 +25,7 @@ pub struct GelfConfig {
 }
 
 #[derive(Deserialize, PartialEq, Eq, Clone, Debug)]
-pub struct ConsoleConfig {
+pub struct StdErrConfig {
     /// E.g. "INFO" or "DEBUG"
     level: String
 }
@@ -45,7 +45,7 @@ pub fn init(config: &LoggingConfig) -> Result<(), Error> {
         eprintln!(
             "Gelf logger config not found => Using environment logger writing to stderr instead."
         );
-        if let Some(ref config) = config.console {
+        if let Some(ref config) = config.stderr {
             env_logger::from_env(env_logger::Env::default().filter_or("THROTTLE_LOG", config.level.as_str())).init();
         } else {
             env_logger::from_env("THROTTLE_LOG").init();

--- a/throttle.toml
+++ b/throttle.toml
@@ -19,6 +19,6 @@
 # level = "INFO"
 
 # Uncomment below lines to log to console.
-# [logging.console]
+# [logging.stderr]
 ## Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
 # level = "INFO"

--- a/throttle.toml
+++ b/throttle.toml
@@ -17,3 +17,8 @@
 # port = 12201
 ## Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
 # level = "INFO"
+
+# Uncomment below lines to log to console.
+# [logging.console]
+## Set this to either ERROR, WARN, INFO, DEBUG or TRACE.
+# level = "INFO"


### PR DESCRIPTION
Extended the logging configuration by a second variable so that the log level for the env_logger can also be defined in the throttle.toml. If the THROTTLE_LOG environment variable is also set, it has precedence.

https://github.com/pacman82/throttle/issues/6