### PR TITLE
Some more tests for python-client and a minor refactoring + fix

### DIFF
--- a/python_client/tests/test_lock.py
+++ b/python_client/tests/test_lock.py
@@ -233,9 +233,12 @@ def test_multiple_peer_recovery_after_server_reboot():
     Verify that a newly booted server, recovers multiple peers based on heartbeats.
     """
     with throttle_client(b"[semaphores]\nA=1\nB=1\nC=1") as client:
-        peerA = client.acquire_with_new_peer("A")
-        peerB = client.acquire_with_new_peer("B")
-        peerC = client.acquire_with_new_peer("C")
+        peerA = client.new_peer()
+        peerB = client.new_peer()
+        peerC = client.new_peer()
+        client.acquire(peerA, "A")
+        client.acquire(peerB, "B")
+        client.acquire(peerC, "C")
 
     # Server is shutdown. Boot a new one wich does not know about the peers
     with throttle_client(b"[semaphores]\nA=1\nB=1\nC=1") as client:

--- a/python_client/tests/test_lock.py
+++ b/python_client/tests/test_lock.py
@@ -149,7 +149,7 @@ def test_exception():
     """
     with throttle_client(b"[semaphores]\nA=1") as client:
         try:
-            with lock("A"):
+            with lock(client, "A"):
                 raise Exception()
         except Exception:
             assert client.remainder("A") == 1


### PR DESCRIPTION
- Added two python tests for multiple semaphores (relates to https://github.com/pacman82/throttle/issues/22 )
- Small refactoring in python-client/lock : introduced a context manager for heartbeat
- Fixed an error in exception-test and added a corresponding bugfix in python-client/lock